### PR TITLE
Actually run pytest in checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         # prerequisites
         python -m pip install --upgrade pip wheel
-        python -m pip install codecov coverage flake8
+        python -m pip install codecov coverage flake8 pytest
         python -m pip install -r tests/requirements.txt
         # install bmlab from main branch
         pip install git+https://github.com/BrillouinMicroscopy/bmlab.git@main
@@ -55,7 +55,7 @@ jobs:
         pip freeze
     - name: Test with pytest
       run: |
-        coverage run --source=bmicro setup.py test
+        coverage run --source=bmicro -m pytest tests
     - name: Lint with flake8
       run: |
         flake8 .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,6 +47,7 @@ jobs:
         # prerequisites
         python -m pip install --upgrade pip wheel
         python -m pip install codecov coverage flake8 pytest
+        python -m pip install -r tests/requirements.txt
         # install bmlab from main branch
         pip install ("git+https://github.com/BrillouinMicroscopy/bmlab.git@main")
         # install dependencies

--- a/.github/workflows/check_stable_pypi.yml
+++ b/.github/workflows/check_stable_pypi.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         # prerequisites
         python -m pip install --upgrade pip wheel
-        python -m pip install codecov coverage flake8
+        python -m pip install codecov coverage flake8 pytest
         python -m pip install -r tests/requirements.txt
         # install dependencies
         pip install -e .
@@ -53,7 +53,7 @@ jobs:
         python -m bmicro --version
     - name: Test with pytest
       run: |
-        coverage run --source=bmicro setup.py test
+        coverage run --source=bmicro -m pytest tests
     - name: Lint with flake8
       run: |
         flake8 .

--- a/tests/gui/test_data_view.py
+++ b/tests/gui/test_data_view.py
@@ -30,7 +30,7 @@ def window(mocker):
 def test_clicking_rotate_updates_session(qtbot, window):
 
     session = Session.get_instance()
-    assert session.orientation.rotation == 1
+    assert session.orientation.rotation == 0
     qtbot.mouseClick(
         window.widget_data_view.radio_rotation_90_cw, QtCore.Qt.LeftButton)
     assert session.orientation.rotation == 3

--- a/tests/gui/test_data_view.py
+++ b/tests/gui/test_data_view.py
@@ -30,7 +30,7 @@ def window(mocker):
 def test_clicking_rotate_updates_session(qtbot, window):
 
     session = Session.get_instance()
-    assert session.orientation.rotation == 0
+    assert session.orientation.rotation == 1
     qtbot.mouseClick(
         window.widget_data_view.radio_rotation_90_cw, QtCore.Qt.LeftButton)
     assert session.orientation.rotation == 3


### PR DESCRIPTION
The first commit in this PR should break all actions/workflows, as one test deliberately fails. But apparently, the tests never run for some workflows, but only for the AppVeyor build.