### PR TITLE
Only update necessary tab when switching tabs

### DIFF
--- a/bmicro/gui/calibration/calibration_view.py
+++ b/bmicro/gui/calibration/calibration_view.py
@@ -85,9 +85,15 @@ class CalibrationView(QtWidgets.QWidget):
 
         calib_keys = session.current_repetition().calibration.image_keys()
         self.combobox_calibration.addItems(calib_keys)
+        self.refresh_plot()
 
     def reset_ui(self):
-        return
+        self.table_Brillouin_regions.setRowCount(0)
+        self.table_Rayleigh_regions.setRowCount(0)
+        self.combobox_calibration.clear()
+        self.calibration_progress.setValue(0)
+        self.plot.cla()
+        self.mplcanvas.draw()
 
     def prev_frame(self):
         if self.current_frame > 0:

--- a/bmicro/gui/calibration/calibration_view.py
+++ b/bmicro/gui/calibration/calibration_view.py
@@ -76,6 +76,19 @@ class CalibrationView(QtWidgets.QWidget):
 
         self.calibration_controller = CalibrationController()
 
+    def update_ui(self):
+        self.combobox_calibration.clear()
+        session = Session.get_instance()
+
+        if not session.file:
+            return
+
+        calib_keys = session.current_repetition().calibration.image_keys()
+        self.combobox_calibration.addItems(calib_keys)
+
+    def reset_ui(self):
+        return
+
     def prev_frame(self):
         if self.current_frame > 0:
             self.current_frame -= 1
@@ -184,16 +197,6 @@ class CalibrationView(QtWidgets.QWidget):
         thread.wait()
 
         self.refresh_plot()
-
-    def update_ui(self):
-        self.combobox_calibration.clear()
-        session = Session.get_instance()
-
-        if not session.file:
-            return
-
-        calib_keys = session.current_repetition().calibration.image_keys()
-        self.combobox_calibration.addItems(calib_keys)
 
     def refresh_plot(self):
         self.plot.cla()

--- a/bmicro/gui/data/data_view.py
+++ b/bmicro/gui/data/data_view.py
@@ -54,11 +54,6 @@ class DataView(QtWidgets.QWidget):
         self.update_ui()
 
     def update_ui(self):
-        """
-        When a new file is selected, update the UI accordingly.
-        """
-        self.reset_ui()
-
         session = Session.get_instance()
         if not session.file:
             return
@@ -68,7 +63,12 @@ class DataView(QtWidgets.QWidget):
         self.label_selected_file.setToolTip(str(session.file.path))
         self.label_selected_file.adjustSize()
         rep_keys = session.file.repetition_keys()
-        self.comboBox_repetition.addItems(rep_keys)
+        # Update repetition keys if they have changed
+        current_keys = [self.comboBox_repetition.itemText(i)
+                        for i in range(self.comboBox_repetition.count())]
+        if current_keys != rep_keys:
+            self.comboBox_repetition.clear()
+            self.comboBox_repetition.addItems(rep_keys)
 
         if rep_keys and self.comboBox_repetition.currentText():
             repetition = session.current_repetition()

--- a/bmicro/gui/data/data_view.py
+++ b/bmicro/gui/data/data_view.py
@@ -106,6 +106,9 @@ class DataView(QtWidgets.QWidget):
         self.label_resolution_z.setText('')
         self.label_calibration.setText('')
         self.textedit_comment.setText('')
+        self.radio_rotation_none.setChecked(True)
+        self.checkbox_reflect_vertically.setChecked(False)
+        self.checkbox_reflect_horizontally.setChecked(False)
         self.update_preview()
 
     def on_rotation_clicked(self):

--- a/bmicro/gui/evaluation/evaluation_view.py
+++ b/bmicro/gui/evaluation/evaluation_view.py
@@ -123,7 +123,14 @@ class EvaluationView(QtWidgets.QWidget):
         return
 
     def reset_ui(self):
-        return
+        self.evaluation_progress.setValue(0)
+        self.plot.cla()
+        # This currently creates problems when opening another
+        # measurement afterwards, since the colorbar is not present.
+
+        # if self.colorbar is not None:
+        #     self.colorbar.remove()
+        self.mplcanvas.draw()
 
     def setup_parameter_selection_combobox(self):
 

--- a/bmicro/gui/evaluation/evaluation_view.py
+++ b/bmicro/gui/evaluation/evaluation_view.py
@@ -119,6 +119,12 @@ class EvaluationView(QtWidgets.QWidget):
         # Might not be necessary anymore once the plot is fast enough.
         self.plot_count = 0
 
+    def update_ui(self):
+        return
+
+    def reset_ui(self):
+        return
+
     def setup_parameter_selection_combobox(self):
 
         param_labels = []

--- a/bmicro/gui/extraction/extraction_view.py
+++ b/bmicro/gui/extraction/extraction_view.py
@@ -63,7 +63,8 @@ class ExtractionView(QtWidgets.QWidget):
         self.combobox_datasets.addItems(calib_keys)
 
     def reset_ui(self):
-        return
+        self.combobox_datasets.clear()
+        self.refresh_image_plot()
 
     def prev_frame(self):
         if self.current_frame > 0:

--- a/bmicro/gui/extraction/extraction_view.py
+++ b/bmicro/gui/extraction/extraction_view.py
@@ -53,6 +53,18 @@ class ExtractionView(QtWidgets.QWidget):
         self.update_ui()
         self.checkFrameNavigationButtons()
 
+    def update_ui(self):
+        session = Session.get_instance()
+        self.combobox_datasets.clear()
+        if not session.current_repetition():
+            return
+
+        calib_keys = session.current_repetition().calibration.image_keys()
+        self.combobox_datasets.addItems(calib_keys)
+
+    def reset_ui(self):
+        return
+
     def prev_frame(self):
         if self.current_frame > 0:
             self.current_frame -= 1
@@ -67,15 +79,6 @@ class ExtractionView(QtWidgets.QWidget):
             self.current_frame += 1
         self.refresh_image_plot()
         self.checkFrameNavigationButtons()
-
-    def update_ui(self):
-        session = Session.get_instance()
-        self.combobox_datasets.clear()
-        if not session.current_repetition():
-            return
-
-        calib_keys = session.current_repetition().calibration.image_keys()
-        self.combobox_datasets.addItems(calib_keys)
 
     def checkFrameNavigationButtons(self):
         if self.current_frame > 0:

--- a/bmicro/gui/main.py
+++ b/bmicro/gui/main.py
@@ -48,6 +48,8 @@ class BMicro(QtWidgets.QMainWindow):
 
         self.setAcceptDrops(True)
 
+        self.reset_ui()
+
     def build_tabs(self):
         self.widget_data_view = data.DataView(self)
         self.layout_data = QtWidgets.QVBoxLayout()
@@ -106,12 +108,38 @@ class BMicro(QtWidgets.QMainWindow):
 
     def close_file(self):
         Session.get_instance().clear()
-        self.update_ui()
+        self.reset_ui()
 
-    def update_ui(self):
-        self.widget_data_view.update_ui()
-        self.widget_extraction_view.update_ui()
-        self.widget_calibration_view.update_ui()
+    def reset_ui(self):
+        """
+        Resets the UI if a file is closed.
+        """
+        self.widget_data_view.reset_ui()
+        self.widget_extraction_view.reset_ui()
+        self.widget_calibration_view.reset_ui()
+        self.widget_peak_selection_view.reset_ui()
+        self.widget_evaluation_view.reset_ui()
+
+    def update_ui(self, new_tab_index=-1):
+        # If no tab index is specified, we update all tabs
+        # (e.g. when a new file is opened).
+        # Otherwise, we only update the newly selected tab.
+        if new_tab_index == -1:
+            self.widget_data_view.update_ui()
+            self.widget_extraction_view.update_ui()
+            self.widget_calibration_view.update_ui()
+            self.widget_peak_selection_view.update_ui()
+            self.widget_evaluation_view.update_ui()
+        elif new_tab_index == 0:
+            self.widget_data_view.update_ui()
+        elif new_tab_index == 1:
+            self.widget_extraction_view.update_ui()
+        elif new_tab_index == 2:
+            self.widget_calibration_view.update_ui()
+        elif new_tab_index == 3:
+            self.widget_peak_selection_view.update_ui()
+        elif new_tab_index == 4:
+            self.widget_evaluation_view.update_ui()
 
     def drag_enter_event(self, event):
         """ Handles dragging a file over the GUI """

--- a/bmicro/gui/peak_selection/peak_selection_view.py
+++ b/bmicro/gui/peak_selection/peak_selection_view.py
@@ -57,7 +57,13 @@ class PeakSelectionView(QtWidgets.QWidget):
 
         self.setupTables()
 
+        self.update_ui()
+
+    def update_ui(self):
         self.refresh_plot()
+
+    def reset_ui(self):
+        return
 
     def on_select_brillouin_clicked(self):
         if self.mode == MODE_SELECT_BRILLOUIN:

--- a/bmicro/gui/peak_selection/peak_selection_view.py
+++ b/bmicro/gui/peak_selection/peak_selection_view.py
@@ -63,7 +63,10 @@ class PeakSelectionView(QtWidgets.QWidget):
         self.refresh_plot()
 
     def reset_ui(self):
-        return
+        self.table_Brillouin_regions.setRowCount(0)
+        self.table_Rayleigh_regions.setRowCount(0)
+        self.plot.cla()
+        self.mplcanvas.draw()
 
     def on_select_brillouin_clicked(self):
         if self.mode == MODE_SELECT_BRILLOUIN:


### PR DESCRIPTION
This changes the UI so that only the necessary tab is updated when switching tabs. This speeds up switching between tabs, prevents the program from crashing when switching tabs while evaluating and ensure the correct data is shown for each tab.

Closes #62 and #56.

Todo:
- [x] Reset calibration, peak-selection and evaluation tab when a file is closed