### PR TITLE
Require python >= 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
                       "scikit-image",
                       "scipy>=0.14.0"
                       ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     keywords=["Brillouin Microscopy"],
     classifiers=['Operating System :: OS Independent',
                  'Programming Language :: Python :: 3',


### PR DESCRIPTION
Python 3.6 is EOL since 2021-12-23, see https://www.python.org/dev/peps/pep-0494/