### PR TITLE
Update pyinstaller version

### DIFF
--- a/build-recipes/macos_build_requirements.txt
+++ b/build-recipes/macos_build_requirements.txt
@@ -1,8 +1,3 @@
 # Any additional requirements for building the application
-pyinstaller>=4.2
-# https://github.com/pyinstaller/pyinstaller/issues/5631
-pyqt5==5.15.3
-# pyinstaller is missing a hook for the latest release of scipy
-scipy<1.5.0
-# this can be removed when PyInstaller<4.7 is released
-numpy<1.22.0
+pyinstaller>=4.8
+

--- a/build-recipes/win_build_requirements.txt
+++ b/build-recipes/win_build_requirements.txt
@@ -1,9 +1,2 @@
 # Any additional requirements for building the application
-pyinstaller>=4.2
-# Got the following error with matplotlib 3.4.1 on appveyor:
-# FileNotFoundError: [Errno 2] No such file or directory: 'C:\\projects\\bmicro\\build-recipes\\dist\\BMicro\\matplotlib\\mpl-data\\matplotlibrc'
-matplotlib==3.3.4
-# https://github.com/pyinstaller/pyinstaller/issues/5631
-pyqt5==5.15.3
-# pyinstaller is missing a hook for the latest release of scipy
-scipy<1.5.0
+pyinstaller>=4.8


### PR DESCRIPTION
PyInstaller@3.8 seems to make the workarounds unnecessary.

The build on AppVeyor succeeded with numpy-1.22.1, matplotlib-3.5.1, scipy-1.7.3 and pyqt5-5.15.6 on all platforms.