### PR TITLE
Make multiprocessing work for BMicro

### DIFF
--- a/bmicro/__main__.py
+++ b/bmicro/__main__.py
@@ -36,4 +36,8 @@ def main():
 
 
 if __name__ == '__main__':
+    # Necessary to make multiprocessing work with pyinstaller
+    from multiprocessing import freeze_support
+    freeze_support()
+
     main()

--- a/bmicro/__main__.py
+++ b/bmicro/__main__.py
@@ -37,7 +37,8 @@ def main():
 
 if __name__ == '__main__':
     # Necessary to make multiprocessing work with pyinstaller
-    from multiprocessing import freeze_support
+    from multiprocessing import freeze_support, set_start_method
     freeze_support()
+    set_start_method('spawn')
 
     main()


### PR DESCRIPTION
This indeed prevents BMicro to open multiple instances when clicking evaluate on Windows and seems to fix the infinite loop with the DMG files on Mac.

Although `freeze_support()` should have no effect on Mac as per python docs.