### PR TITLE
Lock shapely version for macOS

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [macos-latest, ubuntu-latest, windows-latest]
+        exclude:
+          # 3.10 on macOS with shapely 1.8.0 is broken, but shapely >1.8.0 breaks the macOS DMG packages
+          - python-version: '3.10'
+            os: macos-latest
     env:
       # Display must be available globally for linux to know where xvfb is
       DISPLAY: :0

--- a/.github/workflows/check_stable_pypi.yml
+++ b/.github/workflows/check_stable_pypi.yml
@@ -18,6 +18,10 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [macos-latest, ubuntu-latest, windows-latest]
+        exclude:
+          # 3.10 on macOS with shapely 1.8.0 is broken, but shapely >1.8.0 breaks the macOS DMG packages
+          - python-version: '3.10'
+            os: macos-latest
     env:
       # Display must be available globally for linux to know where xvfb is
       DISPLAY: :0

--- a/build-recipes/macos_build_requirements.txt
+++ b/build-recipes/macos_build_requirements.txt
@@ -3,5 +3,6 @@
 # https://github.com/scipy/scipy/issues/15552
 scipy<1.8.0
 pyinstaller>=5.0
+shapely<1.8.1
 bmicro
 


### PR DESCRIPTION
This fixes the "DMG is damaged" error on macOS. Somehow shapely >1.8.0 breaks the codesigning for macOS.