### PR TITLE
Add option to export data

### DIFF
--- a/bmicro/gui/main.py
+++ b/bmicro/gui/main.py
@@ -6,6 +6,8 @@ from PyQt6.QtWidgets import QFileDialog, QMessageBox
 
 from bmlab.session import Session
 
+from bmlab.controllers import ExportController
+
 from . import data
 from . import extraction
 from . import calibration
@@ -97,6 +99,7 @@ class BMicro(QtWidgets.QMainWindow):
         self.action_open.triggered.connect(self.open_file)
         self.action_close.triggered.connect(self.close_file)
         self.action_save.triggered.connect(self.save_session)
+        self.action_export.triggered.connect(self.export_file)
         self.action_exit.triggered.connect(self.exit_app)
 
         self.action_about.triggered.connect(self.on_action_about)
@@ -139,6 +142,9 @@ class BMicro(QtWidgets.QMainWindow):
     def close_file(self):
         Session.get_instance().clear()
         self.reset_ui()
+
+    def export_file(self):
+        ExportController().export()
 
     def reset_ui(self):
         """

--- a/bmicro/gui/main.ui
+++ b/bmicro/gui/main.ui
@@ -82,6 +82,7 @@
     </property>
     <addaction name="action_open"/>
     <addaction name="action_close"/>
+    <addaction name="action_export"/>
     <addaction name="action_save"/>
     <addaction name="separator"/>
     <addaction name="action_exit"/>
@@ -143,6 +144,14 @@
   <action name="action_about">
    <property name="text">
     <string>About</string>
+   </property>
+  </action>
+  <action name="action_export">
+   <property name="text">
+    <string>Export</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+E</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Allows to export Brillouin and Fluorescence data with the default configuration.

Requires https://github.com/BrillouinMicroscopy/bmlab/pull/116 and a new bmlab release.