### PR TITLE
Don't search whole Mac on empty folder name

### DIFF
--- a/bmicro/gui/main.py
+++ b/bmicro/gui/main.py
@@ -735,6 +735,9 @@ class BMicro(QtWidgets.QMainWindow):
             directory=self.settings.value("path/last-used")
         )
 
+        if not folder_name:
+            return
+
         # Find all h5 files in the selected folder
         h5_files = pathlib.Path(folder_name).glob('**/*.h5')
 


### PR DESCRIPTION
In case of an empty folder name (happens when cancelling the select folder dialog), macOS would search the whole mac even including contacts and calendars (not really reasonable, though). This should prevent it.