### PR TITLE
Show BMicro version in about text as well

### DIFF
--- a/bmicro/gui/main.py
+++ b/bmicro/gui/main.py
@@ -247,7 +247,8 @@ class BMicro(QtWidgets.QMainWindow):
     def on_action_about(self):
         gh = "BrillouinMicroscopy/BMicro"
         rtd = "bmicro.readthedocs.io"
-        about_text = "BMicro is a graphical user interface " \
+        about_text = f"BMicro {bmicroversion}<br><br>" \
+            + "BMicro is a graphical user interface " \
             + "for the analysis of Brillouin microscopy data.<br><br>" \
             + f"Using bmlab {bmlabversion}<br><br>" \
             + "Author: Raimund Schlüßler and others<br>" \


### PR DESCRIPTION
macOS does not show the title text of the about dialog, so there is no way of seeing the BMicro version number on macOS. This PR fixes it.