### PR TITLE
Add windows build with python 3.8

### DIFF
--- a/.github/workflows/deploy_github.yml
+++ b/.github/workflows/deploy_github.yml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         python-version: ['3.9']
         os: [macos-latest, windows-latest]
+        include:
+          # Build for Windows 7 with Python 3.8
+          - python-version: '3.8'
+            os: windows-latest
     steps:
     - uses: actions/checkout@v3
       with:
@@ -20,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -40,6 +44,10 @@ jobs:
         .\dist\BMicro\\BMicro.exe --version
         python win_make_iss.py
         iscc /Q win_bmicro.iss
+    - name: Rename release asset for Python 3.8
+      if: (runner.os == 'windows' && matrix.python-version == '3.8')
+      run: |
+        mv ./build-recipes/Output/BMicro_${{ github.ref_name }}_win_64bit_setup.exe ./build-recipes/Output/BMicro_${{ github.ref_name }}_win_7_64bit_setup.exe
     - name: Release macOS assets
       if: runner.os == 'macOS'
       uses: softprops/action-gh-release@v1
@@ -53,7 +61,7 @@ jobs:
           ./build-recipes/dist/BMicro_${{ github.ref_name }}_macosx.dmg
           ./build-recipes/dist/BMicro_${{ github.ref_name }}_macosx.pkg
     - name: Release windows assets
-      if: runner.os == 'windows'
+      if: (runner.os == 'windows' && matrix.python-version == '3.9')
       uses: softprops/action-gh-release@v1
       with:
         name: BMicro ${{ github.ref_name }}
@@ -63,3 +71,14 @@ jobs:
             ![](https://img.shields.io/github/downloads/BrillouinMicroscopy/BMicro/${{ github.ref_name }}/total.svg)
         files: |
           ./build-recipes/Output/BMicro_${{ github.ref_name }}_win_64bit_setup.exe
+    - name: Release windows assets
+      if: (runner.os == 'windows' && matrix.python-version == '3.8')
+      uses: softprops/action-gh-release@v1
+      with:
+        name: BMicro ${{ github.ref_name }}
+        draft: true
+        prerelease: false
+        body: |
+            ![](https://img.shields.io/github/downloads/BrillouinMicroscopy/BMicro/${{ github.ref_name }}/total.svg)
+        files: |
+          ./build-recipes/Output/BMicro_${{ github.ref_name }}_win_7_64bit_setup.exe


### PR DESCRIPTION
This adds a build step to create a BMicro release using Python 3.8 on windows for Windows 7.

Closes #211.