### PR TITLE
Don't disable export button

### DIFF
--- a/bmicro/gui/main.py
+++ b/bmicro/gui/main.py
@@ -229,9 +229,6 @@ class BMicro(QtWidgets.QMainWindow):
         min_box.setEnabled(checked)
         max_box.setEnabled(checked)
 
-        self.export_dialog.button_export.setEnabled(
-            len(self.export_config['brillouin']['parameters']) > 0)
-
     def on_export_minbox(self, value, parameter):
         cax = [value, 'max']
         # We use the existing upper limit if available


### PR DESCRIPTION
Since we also export fluorescence, it is not necessary to disable the export button when all Brillouin parameters are unchecked.