### PR TITLE
Close current file before opening new file

### DIFF
--- a/bmicro/gui/main.py
+++ b/bmicro/gui/main.py
@@ -175,6 +175,7 @@ class BMicro(QtWidgets.QMainWindow):
 
         session = Session.get_instance()
         try:
+            self.close_file()
             session.set_file(file_name)
         except FileNotFoundError as e:
             msg = QMessageBox()


### PR DESCRIPTION
This properly resets the UI (e.g. closes the evaluation spectrum view) before opening a new file.