### PR TITLE
chore: add python 3.13, drop python 3.9

### DIFF
--- a/.github/workflows/check_main_github.yml
+++ b/.github/workflows/check_main_github.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
           # 3.10 on macOS with shapely 1.8.0 is broken, but shapely >1.8.0 breaks the macOS DMG packages

--- a/.github/workflows/check_main_github.yml
+++ b/.github/workflows/check_main_github.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
           # 3.10 on macOS with shapely 1.8.0 is broken, but shapely >1.8.0 breaks the macOS DMG packages

--- a/.github/workflows/check_stable_pypi.yml
+++ b/.github/workflows/check_stable_pypi.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
           # 3.10 on macOS with shapely 1.8.0 is broken, but shapely >1.8.0 breaks the macOS DMG packages

--- a/.github/workflows/check_stable_pypi.yml
+++ b/.github/workflows/check_stable_pypi.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
           # 3.10 on macOS with shapely 1.8.0 is broken, but shapely >1.8.0 breaks the macOS DMG packages

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ setup(
                       "pytest-qt",
                       "pytest_mock",
                       "scikit-image",
-                      "scipy==1.13.1"
+                      "scipy==1.14.1"
                       ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     keywords=["Brillouin Microscopy"],
     classifiers=['Operating System :: OS Independent',
                  'Programming Language :: Python :: 3',


### PR DESCRIPTION
- This PR adds support for Python 3.13
- Updates scipy to 1.14.1
- Drops support for Python 3.9 due to scipy 1.14.1 requiring Python >= 3.10